### PR TITLE
Fix MSTest references and framework

### DIFF
--- a/frontendMonitoringUnittesten/frontendMonitoringUnittesten.csproj
+++ b/frontendMonitoringUnittesten/frontendMonitoringUnittesten.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="MSTest" Version="3.6.4"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- fix MSTest references
- move test project to net8

## Testing
- `dotnet test frontendMonitoringUnittesten/frontendMonitoringUnittesten.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684057f868b88327a08a387840edf4b4